### PR TITLE
Added travis-ci build support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+---
+language: c
+
+os:
+  - linux
+#  - osx
+  
+dist: xenial
+addons:
+  apt:
+    packages:
+    - qt5-default
+    - qt5-qmake 
+    - qtbase5-dev-tools 
+    - qttools5-dev-tools
+    - build-essential
+    - libboost-dev
+    - libboost-system-dev
+    - libboost-filesystem-dev 
+    - libboost-program-options-dev
+    - libboost-thread-dev
+    - libssl-dev
+    - libdb++-dev
+    - libminiupnpc-dev
+before_install:
+#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update                              ; fi
+#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt berkeley-db miniupnpc    ; fi
+#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="/usr/local/opt/qt/bin:$PATH"; fi
+    
+script:
+  - qmake
+  - make

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/erseco/civxd.svg?branch=master)](https://travis-ci.org/erseco/civxd)
+
 # CivX-Qt
 This the the source code repository for the CivX Blockchain Official Wallet.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/erseco/civxd.svg?branch=master)](https://travis-ci.org/erseco/civxd)
+[![Build Status](https://travis-ci.org/exofoundation/CivX-Qt.svg?branch=master)](https://travis-ci.org/exofoundation/CivX-Qt)
 
 # CivX-Qt
 This the the source code repository for the CivX Blockchain Official Wallet.


### PR DESCRIPTION
Added support for travis-ci.org, you should activate it to check if the code is compiling correctly in every PR or commit.

Also I've added a badge in the top of the README.md file, after activating the https://travis-ci.org/exofoundation/CivX-Qt/ you must edit that file to point to your build